### PR TITLE
Fixes for bugs discovered while testing the Hexary Trie

### DIFF
--- a/rlp/writer.nim
+++ b/rlp/writer.nim
@@ -120,6 +120,10 @@ proc appendRawList(self; bytes: BytesRange) =
   output.add(bytes)
   maybeClosePendingLists()
 
+proc appendRawBytes*(self; bytes: BytesRange) =
+  output.add(bytes)
+  maybeClosePendingLists()
+
 proc startList*(self; listSize: int) =
   if listSize == 0:
     appendRawList(BytesRange())

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -1,3 +1,3 @@
 import
-  test_api_usage, test_json_suite, test_object_serialization
+  test_api_usage, test_object_serialization, test_json_suite
 


### PR DESCRIPTION
Bugfixes:

* `rlp.rawData` was returning a wider than necessary range when
  called over a `listElem` result.

* Appending `Rlp` objects to a `RlpWriter` was producing incorrect
  results.

New features:

* When the Rlp reading cursor is positioned over a list, you can call
  `enterList` to position the cursor to the first list element.
  Call `skipElem` to move the cursor further.

* `rlpFromHex` will now accept leading `0x` symbols (often used in the
  Ethereum world).

* `rlp.inspect` will now print hex characters by default. Use the
  optional parameter `hexOutput` to control the behavior.