### PR TITLE
Fix assertion failure on empty byte range

### DIFF
--- a/rlp.nim
+++ b/rlp.nim
@@ -223,13 +223,14 @@ proc toBytes*(self: Rlp): BytesRange =
     raise newException(RlpTypeMismatch,
                        "Bytes expected, but the source RLP in not a blob")
 
-  let
-    payloadOffset = payloadOffset()
-    payloadLen = payloadBytesCount()
-    ibegin = position + payloadOffset
-    iend = ibegin + payloadLen - 1
+  let payloadLen = payloadBytesCount()
+  if payloadLen > 0:
+    let
+      payloadOffset = payloadOffset()
+      ibegin = position + payloadOffset
+      iend = ibegin + payloadLen - 1
 
-  result = bytes.slice(ibegin, iend)
+    result = bytes.slice(ibegin, iend)  
 
 proc currentElemEnd(self: Rlp): int =
   assert hasData()

--- a/tests/test_api_usage.nim
+++ b/tests/test_api_usage.nim
@@ -167,3 +167,8 @@ test "encode byte arrays":
     # The first byte here is the length of the datum (132 - 128 => 4)
     $(rlp.listElem(1).rawData) == "R[132, 6, 8, 12, 123]"
 
+test "empty byte arrays":
+  var
+    rlp = rlpFromBytes rlp.encode("")
+    b = rlp.toBytes
+  check $b == "R[]"


### PR DESCRIPTION
This fixes a number of tests in Nimbus where an empty byte range is requested.