### PR TITLE
avoid being considered a binary-only package by Nimble

### DIFF
--- a/rlp.nimble
+++ b/rlp.nimble
@@ -7,6 +7,8 @@ description   = "RLP serialization library for Nim"
 license       = "Apache License 2.0"
 skipDirs      = @["tests"]
 bin           = @["rlp/bin/rlp_inspect"]
+# avoid being considered a binary-only package: https://github.com/nim-lang/nimble/blob/66d79bf9a0970542351988fa31f487a1e70144f7/src/nimblepkg/packageparser.nim#L280
+installExt    = @["nim"]
 
 requires "nim >= 0.17.0",
          "ranges"


### PR DESCRIPTION
Hidden rules with hidden workarounds:

https://github.com/nim-lang/nimble/blob/66d79bf9a0970542351988fa31f487a1e70144f7/src/nimblepkg/packageparser.nim#L280

https://github.com/nim-lang/nimble/blob/22aa3c1d1392d7878d039250ecf0ffeadf3ba0cc/src/nimble.nim#L907